### PR TITLE
removing strict version requrements for packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,19 +21,19 @@ setup(
             ]
     },
     install_requires=[
-        'click>=6.7,<6.7.99',
-        'pandas>=0.23,<0.23.99',
-        'flask>=1.0,<1.0.99',
-        'Flask-RESTful>=0.3,<0.3.99',
-        'Flask-Testing>=0.7,<0.7.99',
-        'SQLAlchemy>=1.3,<1.3.99',
-        'PyYAML>=5.1,<5.1.99',
-        'requests>=2.19,<2.19.99',
-        'pika>=0.12,<0.12.99',
-        'boto3>=1.7,<1.7.99',
+        'click>=6.7',
+        'pandas>=0.23',
+        'flask>=1.0',
+        'Flask-RESTful>=0.3',
+        'Flask-Testing>=0.7',
+        'SQLAlchemy>=1.3',
+        'PyYAML>=5.1',
+        'requests>=2.19',
+        'pika>=0.12',
+        'boto3>=1.7',
         'geosketch==0.3',
-        'rpy2>=3.0.4,<3.0.99',
-        'tqdm>=4.32,<4.32.99',
-        'cython>=0.29,<0.29.99'
+        'rpy2>=3.0.4',
+        'tqdm>=4.32',
+        'cython>=0.29'
     ],
 )


### PR DESCRIPTION
Hi,

this change simply removes all max package versions from the setup.py script, enabling the CellPhoneDB software to be installed alongside other python software.

The code has been tested, I just can not qualify the results as I have not installed the original version.

I hope that comparing my results to the known test results should be simple. My results on the test examples are linked in the the respective github issue: https://github.com/Teichlab/cellphonedb/issues/231
