### PR TITLE
Error in read files

### DIFF
--- a/cellphonedb/src/plotters/R/plot_dot_by_column_name.R
+++ b/cellphonedb/src/plotters/R/plot_dot_by_column_name.R
@@ -11,8 +11,8 @@ dot_plot = function(selected_rows = NULL,
                     output_extension = '.pdf'
 ){
 
-  all_pval = read.table(pvalues_path, header=T, stringsAsFactors = F, sep=means_separator, comment.char = '', check.names=F)
-  all_means = read.table(means_path, header=T, stringsAsFactors = F, sep=pvalues_separator, comment.char = '', check.names=F)
+  all_pval = read.delim(pvalues_path, header=T, stringsAsFactors = F, sep=means_separator, comment.char = '', check.names=F)
+  all_means = read.delim(means_path, header=T, stringsAsFactors = F, sep=pvalues_separator, comment.char = '', check.names=F)
 
   intr_pairs = all_pval$interacting_pair
   all_pval = all_pval[,-c(1:11)]
@@ -53,7 +53,7 @@ dot_plot = function(selected_rows = NULL,
         panel.border = element_rect(size = 0.7, linetype = "solid", colour = "black"))
 
   if (output_extension == '.pdf') {
-      ggsave(filename, width = width, height = height, device = cairo_pdf, limitsize=F)
+      ggsave(filename, width = width, height = height, limitsize=F)
   }
   else {
       ggsave(filename, width = width, height = height, limitsize=F)

--- a/cellphonedb/src/plotters/R/plot_heatmaps.R
+++ b/cellphonedb/src/plotters/R/plot_heatmaps.R
@@ -7,7 +7,7 @@ heatmaps_plot = function(meta_file, pvalues_file, count_filename, log_filename, 
 
   meta = read.csv(meta_file, comment.char = '', sep=meta_sep)
 
-  all_intr = read.table(pvalues_file, header=T, stringsAsFactors = F, sep=pvalues_sep, comment.char = '', check.names = F)
+  all_intr = read.delim(pvalues_file, header=T, stringsAsFactors = F, sep=pvalues_sep, comment.char = '', check.names = F)
   intr_pairs = all_intr$interacting_pair
   all_intr = all_intr[,-c(1:11)]
 


### PR DESCRIPTION
Using read.table will cause an error if the cell type name contains characters such as "'".